### PR TITLE
added SVG dimension calculation based on viewBox

### DIFF
--- a/lib/img-stats.js
+++ b/lib/img-stats.js
@@ -133,16 +133,30 @@
       var width, height;
       if( fs.readFileSync ){
         var doc = new DOMParser().parseFromString( data.toString( 'utf-8' ) );
+      	viewBox = doc.documentElement.getAttribute( 'viewBox' );
         width = doc.documentElement.getAttribute( 'width' );
+        if ( !width && viewBox ) {
+					width = viewBox.split(' ')[3];
+				}
         height = doc.documentElement.getAttribute( 'height' );
+        if ( !height && viewBox ) {
+					height = viewBox.split(' ')[2];
+				}
         ret.width = width.replace(pxre, "$1");
         ret.height = height.replace(pxre, "$1");
       } else {
         var frag = window.document.createElement( "div" );
         frag.innerHTML = data;
         var svgelem = frag.querySelector( "svg" );
+        viewBox = svgelem.getAttribute( 'viewBox' );
         width = svgelem.getAttribute( "width" );
+        if ( !width && viewBox ) {
+					width = viewBox.split(' ')[3];
+				}
         height = svgelem.getAttribute( "height" );
+        if ( !height && viewBox ) {
+					height = viewBox.split(' ')[2];
+				}
         ret.width = width.replace(pxre, "$1");
         ret.height = height.replace(pxre, "$1");
       }


### PR DESCRIPTION
Sometimes (for instance SVGs generated by Affinity Designer) width and height attributes aren't set on an SVG but viewBox is. In that case an acceptable fallback might be to use these dimensions.